### PR TITLE
Add an "(I)dentify owner" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ rpmdiff.sh [-l | -f | -p] [--nocolor]
 
 ### Environment Variables:
 - `DIFFPROG` override the merge program: (default: 'vim -d')
+- `RPMPROG` override the rpm program to use for the i option: (default: 'rpm')
 - `DIFFSEARCHPATH` override the search path. (only when using find) (default: /etc)
 
 #### Examples:

--- a/rpmdiff.sh
+++ b/rpmdiff.sh
@@ -27,6 +27,7 @@ declare -r myname='rpmdiff'
 declare -r myver='1.0'
 
 diffprog=${DIFFPROG:-'vim -d'}
+rpmprog=${RPMPROG:-'rpm'}
 diffsearchpath=${DIFFSEARCHPATH:-/etc}
 USE_COLOR='y'
 declare -a oldsaves
@@ -84,6 +85,7 @@ General Options:
 
 Environment Variables:
   DIFFPROG          override the merge program: (default: 'vim -d')
+  RPMPROG           override the rpm program: (default: 'rpm')
   DIFFSEARCHPATH    override the search path. (only when using find)
                     (default: /etc)
 
@@ -201,18 +203,22 @@ while IFS= read -u 3 -r -d '' rpmfile; do
     msg2 "Files are identical, removing..."
     rm -v "$rpmfile"
   else
-    ask "(V)iew, (S)kip, (R)emove %s, (O)verwrite with %s, (Q)uit: [v/s/r/o/q] " "$file_type" "$file_type"
+    ask "(V)iew, (S)kip, (R)emove %s, (O)verwrite with %s, (I)dentify owner, (Q)uit: [v/s/r/o/i/q] " "$file_type" "$file_type"
     while read c; do
       case $c in
         q|Q) exit 0;;
         r|R) rm -v "$rpmfile"; break ;;
         o|O) mv -v "$rpmfile" "$file"; break ;;
+        i|I)
+          $rpmprog -qf "$file";
+          ask "(V)iew, (S)kip, (R)emove %s, (O)verwrite with %s, (I)dentify owner, (Q)uit: [v/s/r/o/i/q] " "$file_type" "$file_type";
+          continue ;;
         v|V)
           $diffprog "$rpmfile" "$file"
-          ask "(V)iew, (S)kip, (R)emove %s, (O)verwrite with %s, (Q)uit: [v/s/r/o/q] " "$file_type" "$file_type";
+          ask "(V)iew, (S)kip, (R)emove %s, (O)verwrite with %s, (I)dentify owner, (Q)uit: [v/s/r/o/i/q] " "$file_type" "$file_type";
           continue ;;
         s|S) break ;;
-        *) ask "Invalid answer. Try again: [v/s/r/o/q] "; continue ;;
+        *) ask "Invalid answer. Try again: [v/s/r/o/i/q] "; continue ;;
       esac
     done
   fi


### PR DESCRIPTION
We are using rpmdiff to clean up rpmnew/rpmsave files after updating RPM packages on our servers. Currently the need arose to be able to identify which package owns the target file. This is possible by switching to another terminal and checking with `rpm -qf manually` but having this option built into rpmdiff saves much typing and is much less prone to errors.