### PR TITLE
cp instead mv

### DIFF
--- a/rpmdiff.sh
+++ b/rpmdiff.sh
@@ -208,7 +208,7 @@ while IFS= read -u 3 -r -d '' rpmfile; do
       case $c in
         q|Q) exit 0;;
         r|R) rm -v "$rpmfile"; break ;;
-        o|O) mv -v "$rpmfile" "$file"; break ;;
+        o|O) cp -v "$rpmfile" "$file" && rm "$rpmfile"; break ;;
         i|I)
           $rpmprog -qf "$file";
           ask "(V)iew, (S)kip, (R)emove %s, (O)verwrite with %s, (I)dentify owner, (Q)uit: [v/s/r/o/i/q] " "$file_type" "$file_type";


### PR DESCRIPTION
Changed the `mv`-command to `cp`-command to preserve the
File-Permissions of the original File. Using the `mv`-command
kept the permissions from the rpmsave/rpmnew-file wich
maybe installed with mode `600` and/or `root:root`.
This will mess up the Permissions of the desitination File.

This Patch uses `cp`-command wich keeps the permissions of the
original File.